### PR TITLE
Qhull

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "pybind11"]
 	path = pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "qhull"]
+	path = qhull
+	url = https://github.com/qhull/qhull.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,17 @@ else ()
     message(SEND_ERROR "TINYFILEDIALOGS dependency not met.")
 endif ()
 
+# qhull
+if (BUILD_QHULL)
+    message(STATUS "Building QHULL from source")
+    include_directories("qhull/src")
+    add_subdirectory(qhull)
+    set(qhull_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/qhull/src")
+    set(qhull_LIBRARIES qhullcpp qhullstatic_r) 
+else ()
+    message(SEND_ERROR "qhull dependency not met.")
+endif ()
+
 # rply
 Directories("${CMAKE_CURRENT_SOURCE_DIR}/rply"   rply_INCLUDE_DIRS)
 
@@ -214,7 +225,8 @@ list(APPEND 3RDPARTY_INCLUDE_DIRS
      ${librealsense_INCLUDE_DIRS}
      ${PNG_INCLUDE_DIRS}
      ${rply_INCLUDE_DIRS}
-     ${tinyfiledialogs_INCLUDE_DIRS})
+     ${tinyfiledialogs_INCLUDE_DIRS}
+     ${qhull_INCLUDE_DIRS})
 
 # set 3RDPARTY_INCLUDE_DIRS_AT_INSTALL
 # Open3D's header only dependes on Eigen and GL headers
@@ -240,7 +252,8 @@ list(APPEND 3RDPARTY_LIBRARIES
      ${JPEG_LIBRARIES}
      ${JSONCPP_LIBRARIES}
      ${PNG_LIBRARIES}
-     ${tinyfiledialogs_LIBRARIES})
+     ${tinyfiledialogs_LIBRARIES}
+     ${qhull_LIBRARIES})
 
 # set PRE_BUILT_3RDPARTY_LIBRARIES. When building Open3D as shared library,
 # the user app that links Open3D also need to link PRE_BUILT_3RDPARTY_LIBRARIES,
@@ -263,6 +276,9 @@ if (NOT BUILD_PNG)
 endif ()
 if (NOT BUILD_TINYFILEDIALOGS)
     list(APPEND PRE_BUILT_3RDPARTY_LIBRARIES ${tinyfiledialogs_LIBRARIES})
+endif ()
+if (NOT BUILD_QHULL)
+    list(APPEND PRE_BUILT_3RDPARTY_LIBRARIES ${qhull_LIBRARIES})
 endif ()
 
 set(3RDPARTY_INCLUDE_DIRS ${3RDPARTY_INCLUDE_DIRS} PARENT_SCOPE)

--- a/README.txt
+++ b/README.txt
@@ -61,6 +61,10 @@ tinyfiledialogs             2.7.2                                   zlib license
 A lightweight cross-platform file dialog library
 https://sourceforge.net/projects/tinyfiledialogs/
 --------------------------------------------------------------------------------
+qhull                       2015.2                                      BSD like
+Convex hull, Delauny triangulation, Voronoi diagram, halfspace intersection.
+http://www.qhull.org/
+--------------------------------------------------------------------------------
 pybind11                    2.2                                      BSD license
 Python binding for C++11
 https://github.com/pybind/pybind11


### PR DESCRIPTION
Added Qhull, which has a BSD-like license and is widely used to compute convex hull and more.